### PR TITLE
Fix channel, rates and extended rates

### DIFF
--- a/snap.py
+++ b/snap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# snap.py v1.0 - trustwave spiderlabs
+# snap.py v1.1 - trustwave spiderlabs
 # (Snap)shot SHA256 hashes of wireless access points to determine whether something
 # has changed since your last visit (e.g. rogue AP), plus detect airbase-ng in use.
 #
@@ -9,7 +9,6 @@
 
 from scapy.layers.dot11 import *
 from scapy.sendrecv import sniff
-import chardet
 import hashlib
 import sys
 
@@ -17,15 +16,18 @@ def parse(frame):
     if frame.haslayer(Dot11) and frame.type==0 and frame.subtype==8:
         print("BSSID:", frame.addr3)
         print("SSID:", (frame.info).decode('utf-8'))
-        channel=int(ord(frame[Dot11Elt:3].info))
+        channel=frame.channel
         print("Channel:", channel)
         if frame.haslayer(Dot11EltCountry):
            country=(frame[Dot11EltCountry].country_string).decode('utf-8')
         else:
            country=0
         print("Country:", country)
-        print("Supported Rates:", frame.rates)
-        erates=frame[Dot11EltRates].info
+        print("Supported Rates:", [((i%128)/2)for i in frame.rates])
+        if frame.getlayer(Dot11Elt, ID=50):
+           erates=[((i%128)/2) for i in frame.getlayer(Dot11Elt, ID=50).rates]
+        else:
+           erates=0
         print("Extended Rates:", erates)
         if frame.haslayer(Dot11EltCountryConstraintTriplet):
            power=frame[Dot11EltCountryConstraintTriplet].mtp
@@ -39,10 +41,8 @@ def parse(frame):
         print("Capabilities:", cap)
         if frame.haslayer(Dot11EltHTCapabilities):
            htmax=frame[Dot11EltHTCapabilities].Max_A_MSDU
-           ht=frame[Dot11EltHTCapabilities].summary
         else:
            htmax=0
-           ht=0
         print("Max_A_MSDU:", htmax)
         if frame.haslayer(Dot11EltVendorSpecific):
               try:
@@ -52,11 +52,11 @@ def parse(frame):
         else:
            vendor=0
         print("Vendor:", vendor)
-        all=frame.addr3+str(frame.info)+str(channel)+str(country)+str(vendor)+str(frame.rates)+str(erates)+str(power)+str(cap)+str(htmax)+str(vendor)
+        all=frame.addr3+str(frame.info)+str(channel)+str(country)+str(frame.rates)+str(erates)+str(power)+str(cap)+str(htmax)+str(vendor)
         print("SHA256: "+(hashlib.sha256(all.encode('utf-8')).hexdigest()))
         airbasesig=str(country)+str(frame.rates)+str(erates)+str(power)+str(cap)+str(htmax)+str(vendor)
-#       print("airbase sig: "+(hashlib.sha256(airbasesig.encode('utf-8')).hexdigest()))
-        if hashlib.sha256(airbasesig.encode('utf-8')).hexdigest()=="4c847490293ea0bf0cf2fe7ddb02703368aaf8e97ffb16455f0365a7497e2de2":
+      #   print("airbase sig: "+(hashlib.sha256(airbasesig.encode('utf-8')).hexdigest()))
+        if hashlib.sha256(airbasesig.encode('utf-8')).hexdigest()=="f906ffc81f0f45e5eacb681576138e7256b32ec94dc36ca43b45c86351bb10ba":
            print("******** AIRBASE-NG DETECTED AT THIS ACCESS POINT ********\n")
         else:
            print("")


### PR DESCRIPTION
- Delete the "chardet" import because it wasn't used.
- Modify the way to take channel to avoid potential parsing issues.
- Print the rates and extended rates in Mbit/sec.
- Change the way to take the Extended rates because initially it is just the rates in another format.
- Delete one vendor from the hash because there were two.
- Change the airbase-ng hash because of the modifications.